### PR TITLE
Addresses EOS.undent deprecation warning

### DIFF
--- a/puma-dev.rb
+++ b/puma-dev.rb
@@ -18,7 +18,7 @@ class PumaDev < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
       Setup dev domains:
         sudo puma-dev -setup
 


### PR DESCRIPTION
```
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/customink/homebrew-puma/puma-dev.rb:30:in `caveats'
Please report this to the customink/puma tap!
```